### PR TITLE
Feature/server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jinja2==2.8
 PyYAML==3.11
 SQLAlchemy==1.0.13
 markdown==2.6.6
+livereload==2.4.1

--- a/statik/cmdline.py
+++ b/statik/cmdline.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import argparse
 import logging
+import livereload
 
 from statik.generator import generate
 from statik.utils import generate_quickstart
@@ -34,6 +35,11 @@ def main():
              "directory).",
     )
     parser.add_argument(
+        '--runserver',
+        help="Statik will run a reloading web server at http://0.0.0.0:8000/. The output path must exist outside of the source path or else hot-reload will recurse infinitely.",
+        action='store_true',
+    )
+    parser.add_argument(
         '--quickstart',
         help="Statik will generate a basic directory structure for you in the project directory.",
         action='store_true',
@@ -48,7 +54,14 @@ def main():
     output_path = args.output if args.output is not None else os.path.join(project_path, 'public')
 
     configure_logging(verbose=args.verbose)
-    if args.quickstart:
+    if args.runserver:
+        if output_path.startswith(project_path):
+            raise Exception("The output path cannot exist inside the source path when hot-reloading is enabled.")
+        generate(project_path, output_path=output_path, in_memory=False)
+        server = livereload.Server()
+        server.watch(project_path, lambda: generate(project_path, output_path=output_path, in_memory=False))
+        server.serve(root=output_path, host='0.0.0.0', port=8000)
+    elif args.quickstart:
         generate_quickstart(project_path)
     else:
         generate(project_path, output_path=output_path, in_memory=False)

--- a/statik/cmdline.py
+++ b/statik/cmdline.py
@@ -52,3 +52,7 @@ def main():
         generate_quickstart(project_path)
     else:
         generate(project_path, output_path=output_path, in_memory=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/statik/utils.py
+++ b/statik/utils.py
@@ -118,7 +118,7 @@ def copy_tree(src_path, dest_path):
         if not os.path.isdir(dest_path):
             os.makedirs(dest_path)
 
-        for entry in os.path.listdir(src_path):
+        for entry in os.listdir(src_path):
             src_entry_path = os.path.join(src_path, entry)
             dest_entry_path = os.path.join(dest_path, entry)
             # if it's a sub-folder


### PR DESCRIPTION
RE: #8 

This adds a simple `statik --runserver` command which uses the python module `livereload`/`livereload.js` to run a websever at `http://0.0.0.0:8000/`.

May be worth considering adding more arguments (`host`, `port`, etc) but I think I would quickly choose to incorporate `grunt` or `gulp` before long to pre-process `js`/`css` assets.

Note the bit about how the destination folder should not exist inside the source directory for hot-reloading (or else it recurses on any file change forever).