### PR TITLE
Adds custom template tags (minimal support)

### DIFF
--- a/statik/filters.py
+++ b/statik/filters.py
@@ -7,4 +7,8 @@ def filter_datetime(value, format="%Y-%m-%d %H:%M:%S"):
 
 @register.filter(name="sort_by")
 def filter_sort_by(lst, key):
-    return sorted(lst, key=lambda x: getattr(x, key))
+    reverse = False
+    if key.startswith('-'):
+        reverse = True
+        key = key.lstrip('-')
+    return sorted(lst, key=lambda x: getattr(x, key), reverse=reverse)

--- a/statik/filters.py
+++ b/statik/filters.py
@@ -1,0 +1,10 @@
+from statik.templatetags import register
+
+
+@register.filter(name="date")
+def filter_datetime(value, format="%Y-%m-%d %H:%M:%S"):
+    return value.strftime(format)
+
+@register.filter(name="sort_by")
+def filter_sort_by(lst, key):
+    return sorted(lst, key=lambda x: getattr(x, key))

--- a/statik/tags.py
+++ b/statik/tags.py
@@ -1,0 +1,16 @@
+from statik.templatetags import register
+
+
+@register.simple_tag(name="context", takes_context=True)
+def print_context(context, *args):
+    return context
+
+@register.simple_tag(name="ditto")
+def echo_arguments(*args, **kwargs):
+    """ Echoes all parameters back as text (for debugging)
+            {% ditto 1 2 3 %} => "ditto(1, 2, 3)"
+    """
+    args_string = ', '.join(map(lambda x: str(x), args))
+    kwargs_string = ', '.join(map(lambda k,v: "%s=%s" % (k, v), kwargs.items()))
+    string_lst = filter(lambda x: bool(x), [args_string, kwargs_string])
+    return "ditto(%s)" % ", ".join(string_lst)

--- a/statik/templatetags.py
+++ b/statik/templatetags.py
@@ -1,0 +1,69 @@
+
+
+class TemplateTagStore(object):
+    """
+        To register a template tag:
+            from statik.templatetags import register
+
+            @register.filter
+            def my_filter(object, argument):
+                return object / argument
+    """
+
+    def __init__(self):
+        self.filters = {}
+        self.tags = {}
+        self.takes_context = {}
+
+    def invoke_tag(self, tag_name, context, *args, **kwargs):
+        if self.takes_context[tag_name]:
+            return self.tags[tag_name](context, *args, **kwargs)
+        return self.tags[tag_name](*args, **kwargs)
+
+    def register_tag(self, name, fn):
+        self.tags[name] = fn
+
+    def register_filter(self, name, fn):
+        self.filters[name] = fn
+
+    def simple_tag(self, *args, **kwargs):
+        name = kwargs.pop('name', None)
+        if name:
+            def decorator(fn):
+                print("Registering tag: %s" % name)
+                self.register_tag(name, fn)
+            ret = decorator
+        else:
+            fn = args[0]
+            name = getattr(fn, '_decorated_function', fn).__name__
+            print("Registering tag: %s" % name)
+            self.register_tag(name, fn)
+            ret = None
+
+        # do we need to pass context to tag callable?
+        self.takes_context[name] = kwargs.pop('takes_context', False)
+
+        return ret
+
+    def filter(self, *args, **kwargs):
+        name = kwargs.pop('name', None)
+        if name:
+            def decorator(fn):
+                print("Registering filter: %s" % name)
+                self.register_filter(name, fn)
+            ret = decorator
+        else:
+            fn = args[0]
+            name = getattr(fn, '_decorated_function', fn).__name__
+            print("Registering filter: %s" % name)
+            self.register_filter(name, fn)
+            ret = None
+
+        # do we need to pass context to filter callable?
+        self.takes_context[name] = kwargs.pop('takes_context', False)
+
+        return ret
+
+
+store = TemplateTagStore()
+register = store  # for clarity when using decorators

--- a/statik/utils.py
+++ b/statik/utils.py
@@ -4,6 +4,7 @@ import os
 import os.path
 from copy import deepcopy, copy
 import shutil
+import importlib
 
 import logging
 logger = logging.getLogger(__name__)
@@ -20,6 +21,7 @@ __all__ = [
     'calculate_association_table_name',
     'get_url_file_ext',
     'generate_quickstart',
+    'import_python_modules_by_path'
 ]
 
 DEFAULT_CONFIG_CONTENT = """project-name: Your project name
@@ -167,3 +169,11 @@ def ensure_file_exists(path, default_content):
         logger.info('Creating file: %s' % path)
         with open(path, 'wt') as f:
             f.write(default_content)
+
+
+def import_python_modules_by_path(path):
+    for filename in list_files(path, "py"):
+        name = extract_filename(filename)
+        spec = importlib.util.spec_from_file_location(name, os.path.join(path, filename))
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)


### PR DESCRIPTION
So I just needed to be able to sort my menu items using an integer `order` attribute and there was no easy way to accomplish it (or maybe I wasn't clever enough). So I added custom template tags so I could roll my own `sort_by` filter.

RE: #7

- Dynamically loads python modules found at `project/templatetags/` path
- Adds `@register.filter` and `@register.simple_tag` decorators
    - The decorators accept arguments `name` and `takes_context`
- Adds `ditto` and `context` tags:
    - `{% ditto 1 2 3 %}` merely echoes the parameters back: `ditto(1, 2, 3)`
    - `{% context %}` prints the context dictionary out for debugging
- Adds `sort_by` filter

Code is separated like so:

- `templatetags.py` for the custom template tag store / decorators
- `jinja2ext.py` for the jinja2 custom template tag extension
- `tags.py` for any built-in template tags (e.g. `ditto`)
- `filters.py` for any built-in filters (e.g. `date`)

Known issues:

- No keyword arguments for template tags
- Python modules are not reloaded during `--watch` but perhaps this would not be hard to add (i.e. for the project `templatetags/` modules.
- Needs docs if you are happy with this approach