### PR TITLE
Add 'encoding' config option to allow / force opening files with a specific encoding

### DIFF
--- a/statik/common.py
+++ b/statik/common.py
@@ -21,7 +21,7 @@ class YamlLoadable(object):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             self.filename = args[0]
-            with open(self.filename, 'rt') as f:
+            with open(self.filename, mode='rt', encoding='utf-8') as f:
                 self.file_content = f.read()
 
         elif 'from_string' in kwargs:
@@ -61,7 +61,7 @@ class ContentLoadable(object):
                     raise ValueError("File is not a YAML or Markdown-formatted file")
                 self.file_type = 'yaml' if (ext in ['yml', 'yaml']) else 'markdown'
 
-            with open(self.filename, 'rt') as f:
+            with open(self.filename, mode='rt', encoding='utf-8') as f:
                 self.file_content = f.read()
 
         elif 'from_string' in kwargs:

--- a/statik/common.py
+++ b/statik/common.py
@@ -21,7 +21,12 @@ class YamlLoadable(object):
     def __init__(self, *args, **kwargs):
         if len(args) > 0:
             self.filename = args[0]
-            with open(self.filename, mode='rt', encoding='utf-8') as f:
+
+            self.encoding = None
+            if 'encoding' in kwargs:
+                self.encoding = kwargs['encoding']
+
+            with open(self.filename, mode='rt', encoding=self.encoding) as f:
                 self.file_content = f.read()
 
         elif 'from_string' in kwargs:
@@ -55,13 +60,18 @@ class ContentLoadable(object):
 
         if len(args) > 0:
             self.filename = args[0]
+
+            self.encoding = None
+            if 'encoding' in kwargs:
+                self.encoding = kwargs['encoding']
+
             if self.file_type is None:
                 ext = list(os.path.splitext(self.filename))[1].lstrip('.')
                 if ext not in ['yml', 'yaml', 'md', 'markdown']:
                     raise ValueError("File is not a YAML or Markdown-formatted file")
                 self.file_type = 'yaml' if (ext in ['yml', 'yaml']) else 'markdown'
 
-            with open(self.filename, mode='rt', encoding='utf-8') as f:
+            with open(self.filename, mode='rt', encoding=self.encoding) as f:
                 self.file_content = f.read()
 
         elif 'from_string' in kwargs:

--- a/statik/config.py
+++ b/statik/config.py
@@ -19,6 +19,7 @@ class StatikConfig(YamlLoadable):
         super().__init__(*args, **kwargs)
         self.project_name = self.vars.get('project-name', 'Untitled project')
         self.base_path = self.vars.get('base-path', '/')
+        self.encoding = self.vars.get('encoding')
         # relative to the output folder
         self.assets_src_path = self.assets_dest_path = 'assets'
         if 'assets' in self.vars and isinstance(self.vars['assets'], dict):
@@ -43,10 +44,11 @@ class StatikConfig(YamlLoadable):
     def __repr__(self):
         return ("<StatikConfig project_name=%s\n" +
                 "              base_path=%s\n" +
+                "              encoding=%s\n" +
                 "              assets_src_path=%s\n" +
                 "              assets_dest_path=%s\n" +
                 "              context_static=%s\n" +
                 "              context_dynamic=%s>") % (
-                    self.project_name, self.base_path, self.assets_src_path,
+                    self.project_name, self.base_path, self.encoding, self.assets_src_path,
                     self.assets_dest_path, self.context_static, self.context_dynamic
                 )

--- a/statik/database.py
+++ b/statik/database.py
@@ -164,7 +164,7 @@ class StatikDatabase(object):
     def load_model_data_collection(self, path, model):
         db_model = globals()[model.name]
         # load the collection data from the collection file
-        with open(os.path.join(path, '_all.yml'), mode='rt', encoding='utf-8') as f:
+        with open(os.path.join(path, '_all.yml'), mode='rt', encoding=self.encoding) as f:
             collection = yaml.load(f.read())
 
         if not isinstance(collection, list):

--- a/statik/database.py
+++ b/statik/database.py
@@ -161,7 +161,7 @@ class StatikDatabase(object):
     def load_model_data_collection(self, path, model):
         db_model = globals()[model.name]
         # load the collection data from the collection file
-        with open(os.path.join(path, '_all.yml'), 'rt') as f:
+        with open(os.path.join(path, '_all.yml'), mode='rt', encoding='utf-8') as f:
             collection = yaml.load(f.read())
 
         if not isinstance(collection, list):

--- a/statik/database.py
+++ b/statik/database.py
@@ -52,13 +52,16 @@ def clear_tracked_globals():
 
 class StatikDatabase(object):
 
-    def __init__(self, data_path, models):
+    def __init__(self, data_path, models, encoding):
         """Constructor.
 
         Args:
             data_path: The full path to where the database files can be found.
             models: Loaded model/field data.
+            encoding: The encoding to load files as ('utf-8', etc). If 'None', will
+                      default to the system-preferred default encoding
         """
+        self.encoding = encoding
         self.tables = dict()
         self.data_path = data_path
         self.models = models
@@ -181,6 +184,7 @@ class StatikDatabase(object):
                 from_dict=item,
                 model=model,
                 session=self.session,
+                encoding=self.encoding
             )
             # duplicate primary key!
             if entry.field_values['pk'] in seen_entries:
@@ -203,6 +207,7 @@ class StatikDatabase(object):
                 os.path.join(path, entry_file),
                 model=model,
                 session=self.session,
+                encoding=self.encoding
             )
             # duplicate primary key!
             if entry.field_values['pk'] in seen_entries:

--- a/statik/project.py
+++ b/statik/project.py
@@ -75,6 +75,12 @@ class StatikProject(object):
                 raise ValueError("If project is not to be generated in-memory, an output path must be specified")
 
             self.config = self.config or StatikConfig(self.config_file_path)
+
+            if self.config.encoding != None:
+                logger.info("Using encoding: %s" % self.config.encoding)
+            else:
+                logger.debug("Using encoding: %s" % self.config.encoding)
+
             self.models = self.load_models()
             self.template_env = self.configure_templates()
 
@@ -162,6 +168,7 @@ class StatikProject(object):
             model_name = extract_filename(model_file)
             models[model_name] = StatikModel(
                 os.path.join(models_path, model_file),
+                encoding=self.config.encoding,
                 name=model_name,
                 model_names=model_names
             )
@@ -183,6 +190,7 @@ class StatikProject(object):
             view_name = extract_filename(view_file)
             views[view_name] = StatikView(
                 os.path.join(view_path, view_file),
+                encoding=self.config.encoding,
                 name=view_name,
                 models=self.models,
                 template_env=self.template_env,
@@ -196,7 +204,7 @@ class StatikProject(object):
         if not os.path.isdir(data_path):
             raise MissingProjectFolderError(StatikProject.DATA_DIR, "Project is missing its data folder")
 
-        return StatikDatabase(data_path, models)
+        return StatikDatabase(data_path, models, self.config.encoding)
 
     def load_project_context(self):
         """Loads the project context (static and dynamic) from the database/models for common use amongst


### PR DESCRIPTION
I originally created my site on my Linux box, and everything worked fine. Unfortunately, one day I tried to build my site on a Windows machine and kept getting the following error:

```
Error caught: 'charmap' codec can't decode byte 0x9d in position 179: character maps to <undefined>
Unable to clean up properly: 'NoneType' object has no attribute 'shutdown'
```

The issue was that Python was opening all of my files using Windows' `cp1252` encoding, when several of my source files were actually saved as `utf-8` encoded. By specifying the encoding named parameter in the `open` functions, you can tell Python to use a specific encoding rather than that platform's default one; so this is basically what the PR does.

It adds an config variable named `encoding`, which when set, will open all text files using that encoding. If the variable isn't set, it defaults to `None`, and things return to the original behaviour.

Let me know if you see any issues, and thanks for making a great tool for people like myself!