### PR TITLE
fixes utils.get_url_file_ext to work with dotfiles

### DIFF
--- a/statik/utils.py
+++ b/statik/utils.py
@@ -186,8 +186,14 @@ def calculate_association_table_name(model1_name, model2_name):
 def get_url_file_ext(url):
     """Attempts to extract the file extension from the given URL."""
     # get the last part of the path component
-    filename = url.split('/')[-1]
-    _, ext = os.path.splitext(filename)
+
+    filename = os.path.basename(url)
+    name, ext = os.path.splitext(filename)
+
+    # handle case of files with leading dot
+    if not ext and name and name[0] == '.':
+        ext = name
+
     return ext
 
 

--- a/statik/views.py
+++ b/statik/views.py
@@ -166,6 +166,7 @@ class StatikView(YamlLoadable):
             path = add_url_path_component(self.path, '%s%s' % (self.default_output_filename, self.default_output_ext))
         else:
             path = self.path
+        logger.debug("Simple view %s generated path %s" % (self.name, path))
         return dict_from_path(
                 path,
                 final_value=self.template.render(self.context),

--- a/tests/modular/test_utils.py
+++ b/tests/modular/test_utils.py
@@ -39,6 +39,52 @@ class TestStatikUtils(unittest.TestCase):
             strip_el_text(tree, max_depth=3)
         )
 
+    def test_get_url_file_ext(self):
+        self.assertEqual(
+            get_url_file_ext('index.html'),
+            '.html'
+        )
+        self.assertEqual(
+            get_url_file_ext('/'),
+            ''
+        )
+        self.assertEqual(
+            get_url_file_ext('/path'),
+            ''
+        )
+        self.assertEqual(
+            get_url_file_ext('/longer/path'),
+            ''
+        )
+        self.assertEqual(
+            get_url_file_ext('/longer/path/trailing/slash/'),
+            ''
+        )
+        self.assertEqual(
+            get_url_file_ext('/path/to/test.html'),
+            '.html'
+        )
+        self.assertEqual(
+            get_url_file_ext('.htaccess'),
+            '.htaccess'
+        )
+        self.assertEqual(
+            get_url_file_ext('/.dot'),
+            '.dot'
+        )
+        self.assertEqual(
+            get_url_file_ext('/directory/with/leading/.dot/'),
+            ''
+        )
+        self.assertEqual(
+            get_url_file_ext('/path.htaccess'),
+            '.htaccess'
+        )
+        self.assertEqual(
+            get_url_file_ext('/multiple//slashes///slash'),
+            ''
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This commit fixes utils.get_url_file_ext to correctly handle paths
like '.htaccess' with leading dots to avoid issue of statik generating
URLs like '.htaccess/index.html'.

Fixes #40.