### PR TITLE
Allow dynaimcally loading jinja2 and Markdown extensions from user config

### DIFF
--- a/statik/common.py
+++ b/statik/common.py
@@ -122,13 +122,9 @@ class ContentLoadable(object):
                             permalink_title=self.markdown_config.permalink_title,
                         )
                     )
-                markdown_ext.extend([
-                    'markdown.extensions.fenced_code',
-                    'markdown.extensions.tables',
-                    'markdown.extensions.toc',
-                    'markdown.extensions.footnotes'
-                ])
-                md = Markdown(extensions=markdown_ext)
+                markdown_ext.extend(self.markdown_config.extensions)
+
+                md = Markdown(extensions=markdown_ext, extension_configs=self.markdown_config.extension_config)
                 self.content = md.convert(self.file_content)
                 self.vars = md.meta
 

--- a/statik/markdown_config.py
+++ b/statik/markdown_config.py
@@ -38,8 +38,14 @@ class MarkdownConfig(object):
 
         # Try to load in entensions requested by config
         for extention, config in markdown_params.get('extensions', dict()).items():
-            self.extensions.append(extention)
-            self.extension_config[extention] = config
+            if extention not in self.extensions:
+                self.extensions.append(extention)
+
+            if config is not None: 
+                if extention in self.extension_config:
+                    self.extension_config[extention].update(config)
+                else:
+                    self.extension_config[extention] = config
 
     def __repr__(self):
         return ("<MarkdownConfig enable_permalinks=%s\n" +

--- a/statik/markdown_config.py
+++ b/statik/markdown_config.py
@@ -25,6 +25,22 @@ class MarkdownConfig(object):
         self.permalink_class = permalinks_config.get('class', None)
         self.permalink_title = permalinks_config.get('title', None)
 
+        # Required lsit of Markdown extensions
+        self.extensions = [
+            'markdown.extensions.fenced_code',
+            'markdown.extensions.tables',
+            'markdown.extensions.toc',
+            'markdown.extensions.footnotes'
+        ]
+
+        # Configuration for the markdown extensions
+        self.extension_config = {}
+
+        # Try to load in entensions requested by config
+        for extention, config in markdown_params.get('extensions', dict()).items():
+            self.extensions.append(extention)
+            self.extension_config[extention] = config
+
     def __repr__(self):
         return ("<MarkdownConfig enable_permalinks=%s\n" +
                 "                permalink_text=%s\n" +

--- a/statik/templating.py
+++ b/statik/templating.py
@@ -225,18 +225,23 @@ class StatikJinjaTemplateProvider(StatikTemplateProvider):
             # dynamically import modules; they register themselves with our template tag store
             import_python_modules_by_path(self.templatetags_path)
 
+        extensions = [
+            'statik.jinja2ext.StatikUrlExtension',
+            'statik.jinja2ext.StatikAssetExtension',
+            'statik.jinja2ext.StatikLoremIpsumExtension',
+            'statik.jinja2ext.StatikTemplateTagsExtension',
+            'jinja2.ext.do',
+            'jinja2.ext.loopcontrols',
+            'jinja2.ext.with_',
+            'jinja2.ext.autoescape',
+        ]
+
+        jinja2_config = project.config.vars.get('jinja2', dict())
+        extensions.extend(jinja2_config.get('extensions', list()))
+
         self.env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(engine.template_paths, encoding=project.config.encoding),
-            extensions=[
-                'statik.jinja2ext.StatikUrlExtension',
-                'statik.jinja2ext.StatikAssetExtension',
-                'statik.jinja2ext.StatikLoremIpsumExtension',
-                'statik.jinja2ext.StatikTemplateTagsExtension',
-                'jinja2.ext.do',
-                'jinja2.ext.loopcontrols',
-                'jinja2.ext.with_',
-                'jinja2.ext.autoescape',
-            ]
+            extensions=extensions
         )
 
         if templatetags.store.filters:


### PR DESCRIPTION
This PR fixes #6 by allowing markdown extensions to by dynamically loaded and configured by the server through the use of a user's `config.yaml`

The following example will load the Code Highlight extention for Markdown and configure it to use `highlight` css class instead of the default `codehilite` class.  Which can then be styled usign a css file from https://github.com/richleland/pygments-css
```yml
project-name: Portfolio Website for NZSmartie
base-path: /
markdown:
  extensions:
    markdown.extensions.codehilite:
      css_class: 'highlight'
```

Additionally, jinja2 extensions may be added:
```yml
project-name: Portfolio Website for NZSmartie
base-path: /
jinja2:
  extensions:
    - jinja2_HelloWorld
```