### PR TITLE
fix #49

### DIFF
--- a/statik/views.py
+++ b/statik/views.py
@@ -184,4 +184,4 @@ class StatikView(YamlLoadable):
                 {self.path_variable: inst}
         ) if self.complex else self.path
 
-        return result
+        return result if result.endswith('/') else ('%s/' % result)


### PR DESCRIPTION
This was removed in a previous commit, but it breaks urls for some reason, as described in #49.
I just restored this line from cdc675b671d49781138115a450e8b8fa7ddf5fa8, where it was still working