### PR TITLE
Add SFTP upload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ repository. Watch that space!
 To publish your website on a server via SFTP, you can use the remote upload command 
 line option. The connection parameters must be added to your project's `config.yml`.
  
-``
+```
 remote:
     sftp:
         server: 'hostname or IP'

--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@ Themes for **Statik** will slowly start appearing in the
 [Statik Themes](https://github.com/thanethomson/statik-themes)
 repository. Watch that space!
 
+## Remote upload
+
+To publish your website on a server via SFTP, you can use the remote upload command 
+line option. The connection parameters must be added to your project's `config.yml`.
+ 
+``
+remote:
+    sftp:
+        server: 'hostname or IP'
+        dir-base: '/base/directory/'
+        dir-root: 'relative/to/base/directory'  
+        username: 'SSH username'
+        password: 'SSH password'
+```
+
 ## License
 **The MIT License (MIT)**
 

--- a/statik/cmdline.py
+++ b/statik/cmdline.py
@@ -15,6 +15,7 @@ from statik.utils import generate_quickstart, get_project_config_file
 from statik.watcher import watch
 from statik.project import StatikProject
 from statik.errors import StatikError, StatikErrorContext
+from statik.upload import upload_sftp
 
 import logging
 logger = logging.getLogger(__name__)
@@ -103,6 +104,11 @@ def main():
         help="Run Statik in safe mode (which disallows unsafe query execution)"
     )
     parser.add_argument(
+        '-u', '--upload',
+        action='store',
+        help="Upload project to remote location (supported: SFTP)"
+    )
+    parser.add_argument(
         '-v', '--verbose',
         help="Whether or not to output verbose logging information (default: false).",
         action='store_true',
@@ -183,6 +189,12 @@ def main():
                 safe_mode=args.safe_mode,
                 error_context=error_context
             )
+
+        if args.upload and args.upload == 'SFTP':
+                upload_sftp(
+                    config_file_path,
+                    output_path
+                )
 
     except StatikError as e:
         sys.exit(e.exit_code)

--- a/statik/upload.py
+++ b/statik/upload.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import os
+
+import paramiko
+
+from statik.config import StatikConfig
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    'upload_sftp',
+]
+
+
+def mkdir_p(sftp, path):
+    """Create remote path including parent directories if needed
+    https://stackoverflow.com/a/14819803
+    """
+    try:
+        sftp.chdir(path)
+    except IOError:
+        dirname, basename = os.path.split(path.rstrip('/'))
+        mkdir_p(sftp, dirname)
+        sftp.mkdir(basename)
+        sftp.chdir(basename)
+        return True
+
+
+def rm_r(sftp, path):
+    """Recursively delete contents of path
+    https://stackoverflow.com/a/23256181
+    """
+    files = sftp.listdir(path)
+    for f in files:
+        filepath = os.path.join(path, f)
+        logger.info('Deleting: %s' % (filepath))
+        try:
+            sftp.remove(filepath)
+        except IOError:
+            rm_r(sftp, filepath)
+
+
+def upload_sftp(input_path, output_path, rm_remote=False):
+    ssh_config = StatikConfig(input_path).remote['sftp']
+
+    t = paramiko.Transport((ssh_config['server'], 22))
+
+    t.connect(username=ssh_config['username'], password=ssh_config['password'])
+    logger.info('Connecting to %s...' % ssh_config['server'])
+
+    sftp = paramiko.SFTPClient.from_transport(t)
+    logger.info('Connected to %s...' % ssh_config['server'])
+
+    if rm_remote:
+        path = ssh_config['dir-base'] + ssh_config['dir-root']
+        rm_r(sftp, path)
+
+    for root, dirs, files in os.walk(output_path):
+        for f in files:
+            localpath = root + '/' + f
+            dirname = root.replace(output_path, ssh_config['dir-root'], 1)
+            remotepath = dirname + '/' + f
+            logger.info('Publishing: %s' % (ssh_config['dir-base'] + remotepath))
+            try:
+                mkdir_p(sftp, ssh_config['dir-base'] + dirname)
+            except:
+                pass
+            sftp.put(localpath, ssh_config['dir-base'] + remotepath)
+
+    sftp.close()
+    logger.info('Connection closed.')


### PR DESCRIPTION
Adding basic SFTP upload functionality which can be started using a new command line option. Connection parameters including SSH credentials (currently username/passwords only) go in the project's config.yml file.