### PR TITLE
reorganized and extended cmdline.py

### DIFF
--- a/statik/cmdline.py
+++ b/statik/cmdline.py
@@ -55,71 +55,86 @@ def main():
         description="Statik: a static web site generator for developers."
     )
     parser.add_argument(
-        '--version',
-        help='Display version info for Statik',
-        action='store_true',
+        '-p', '--project',
+        help="The path to your Statik project or project YAML configuration file (default: current directory).",
     )
     parser.add_argument(
         '--quickstart',
         help="Statik will generate a basic directory structure for you in the project directory and exit.",
         action='store_true',
     )
-    parser.add_argument(
-        '-p', '--project',
-        help="The path to your Statik project or project YAML configuration file (default: current directory).",
-    )
-    parser.add_argument(
+
+    group_generate = parser.add_argument_group('static site generation')
+    group_generate.add_argument(
         '-o', '--output',
         help="The output path into which to place the built project (default: \"public\" directory in input " +
              "directory).",
     )
-    parser.add_argument(
-        '-w', '--watch',
-        help="Statik will watch the project path for changes and automatically regenerate the project. " +
-             "This also runs a small HTTP server to serve your output files.",
+    group_generate.add_argument(
+        '--clear-output',
         action='store_true',
+        help="Clears the output folder first prior to building the project. If watching " +
+            "is initiated, this will only clear the output folder once-off."
     )
-    parser.add_argument(
-        '--host',
-        help="When watching a folder for changes (--watch), this specifies the host IP address or hostname to which " +
-             "to bind (default: localhost).",
-        default='localhost',
-    )
-    parser.add_argument(
-        '--port',
-        help="When watching a folder for changes (--watch), this specifies the port to which to bind (default: 8000).",
-        type=int,
-        default=8000,
-    )
-    parser.add_argument(
-        '-n', '--no-browser',
-        action='store_true',
-        default=False,
-        help="Do not attempt to automatically open a web browser at the served URL when watching for changes"
-    )
-    parser.add_argument(
+    group_generate.add_argument(
         '-s', '--safe-mode',
         action='store_true',
         default=False,
         help="Run Statik in safe mode (which disallows unsafe query execution)"
     )
-    parser.add_argument(
+
+    group_server = parser.add_argument_group('built-in server')
+    group_server.add_argument(
+        '-w', '--watch',
+        help="Statik will watch the project path for changes and automatically regenerate the project. " +
+             "This also runs a small HTTP server to serve your output files.",
+        action='store_true',
+    )
+    group_server.add_argument(
+        '--host',
+        help="When watching a folder for changes (--watch), this specifies the host IP address or hostname to which " +
+             "to bind (default: localhost).",
+        default='localhost',
+    )
+    group_server.add_argument(
+        '--port',
+        help="When watching a folder for changes (--watch), this specifies the port to which to bind (default: 8000).",
+        type=int,
+        default=8000,
+    )
+    group_server.add_argument(
+        '-n', '--no-browser',
+        action='store_true',
+        default=False,
+        help="Do not attempt to automatically open a web browser at the served URL when watching for changes"
+    )
+
+    group_remote = parser.add_argument_group('remote publishing')
+    group_remote.add_argument(
         '-u', '--upload',
         action='store',
         help="Upload project to remote location (supported: SFTP)"
     )
-    parser.add_argument(
+    group_remote.add_argument(
+        '-c', '--clear-remote',
+        action='store_true',
+        help="CAUTION: This will delete ALL files and subfolders in the remote folder before uploading the generated files. " + 
+             "If the subsequent upload fails, your website will no longer be online."
+    )
+
+    group_info = parser.add_argument_group('information about Statik')
+    group_info.add_argument(
         '-v', '--verbose',
         help="Whether or not to output verbose logging information (default: false).",
         action='store_true',
     )
-    parser.add_argument(
+    group_info.add_argument(
         '--quiet',
         default=False,
         help="Run Statik in quiet mode, where there will be no output except upon error.",
         action='store_true'
     )
-    parser.add_argument(
+    group_info.add_argument(
         '--fail-silently',
         default=False,
         help="Only relevant if running Statik in quiet mode - if Statik encounters an error, the only indication "
@@ -127,17 +142,16 @@ def main():
              "on the terminal.",
         action='store_true'
     )
-    parser.add_argument(
+    group_info.add_argument(
         '--no-colorlog',
         action='store_true',
         help="By default, Statik outputs logging data in colour. By specifying this switch, " +
              "coloured logging will be turned off."
     )
-    parser.add_argument(
-        '--clear-output',
+    group_info.add_argument(
+        '--version',
+        help='Display version info for Statik',
         action='store_true',
-        help="Clears the output folder first prior to building the project. If watching " +
-            "is initiated, this will only clear the output folder once-off."
     )
     args = parser.parse_args()
 
@@ -182,6 +196,13 @@ def main():
         elif args.quickstart:
             generate_quickstart(project_path)
         else:
+            if args.host and '--host=localhost' in sys.argv[1:]:
+                logger.warning("Ignoring --host argument because --watch is not specified")
+            if args.port and '--port=8000' in sys.argv[1:]:
+                logger.warning("Ignoring --port argument because --watch is not specified")
+            if args.no_browser:
+                logger.warning("Ignoring --no-browser argument because --watch is not specified")
+
             generate(
                 config_file_path,
                 output_path=output_path,
@@ -193,8 +214,12 @@ def main():
         if args.upload and args.upload == 'SFTP':
                 upload_sftp(
                     config_file_path,
-                    output_path
+                    output_path,
+                    rm_remote=args.clear_remote
                 )
+        else:
+            if args.clear_remote:
+                logger.warning("Ignoring --clear-remote switch because --upload is not specified")
 
     except StatikError as e:
         sys.exit(e.exit_code)


### PR DESCRIPTION
- These changes start organizing the increasing list of command line arguments. I propose the parser groups: static site generation, built-in server, remote publishing, information about Statik

- The one new option `--clear-remote` must be used with caution. It cleans up the files/folders on the server, but there is some downtime between deletion and upload, and the site would stay offline if the subsequent upload fails.