### PR TITLE
appveyor.yml: Add appveyor build config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  - "%PYTHON%\\python.exe --version"
+
+build: off
+
+test_script:
+  - "%PYTHON%\\python.exe -m unittest discover"


### PR DESCRIPTION
Add appveyor.yml to allow for appveyor builds

Closes https://github.com/thanethomson/statik/issues/83

Runs builds on Python versions 2.7, 3.5, 3.6, and 3.7: https://ci.appveyor.com/project/kx-chen/statik