### PR TITLE
database.py: check for non-string elements in array

### DIFF
--- a/statik/database.py
+++ b/statik/database.py
@@ -428,6 +428,13 @@ class StatikDatabaseInstance(ContentLoadable):
                                    field_name)
                     self.field_values[field_name] = list(set(self.field_values[field_name]))
 
+                # check if non-string items are present
+                for item in self.field_values[field_name]:
+                    if not isinstance(item, ("".__class__, u"".__class__)):
+                        logger.warning("Non-string values found in array " + 
+                                        "(field: %s, instance: %s, model: %s): %s",
+                                        field_name, self.field_values['pk'], self.model.name, item)
+
                 # convert the list of field values to a query to look up the
                 # primary keys of the corresponding table
                 other_model = globals()[field.field_type]

--- a/tests/modular/test_nonascii.py
+++ b/tests/modular/test_nonascii.py
@@ -10,6 +10,10 @@ from statik.markdown_config import MarkdownConfig
 
 TEST_MARKDOWN_CONTENT = """---
 title: This is a “title” with some non-standard characters
+
+unicode:
+    - "\u2ffa"
+    - "\u2ffb"
 ---
 This is the “Markdown” body with some other non-standard characters.
 """
@@ -27,6 +31,10 @@ class TestNonAsciiChars(unittest.TestCase):
         self.assertEqual(
             "This is a “title” with some non-standard characters",
             parsed.vars['title'],
+        )
+        self.assertEqual(
+            ['⿺', '⿻'],
+            parsed.vars['unicode']
         )
         self.assertEqual(
             "<p>This is the “Markdown” body with some other non-standard characters.</p>",


### PR DESCRIPTION
Added check for non-string elements in array.

Closes https://github.com/thanethomson/statik/issues/79