### PR TITLE
Load all files in a data directory: "_all.yml" and other files if present

### DIFF
--- a/statik/database.py
+++ b/statik/database.py
@@ -204,8 +204,7 @@ class StatikDatabase(object):
             # try find a model data collection
             if os.path.isfile(os.path.join(path, '_all.yml')):
                 self.load_model_data_collection(path, model)
-            else:
-                self.load_model_data_from_files(path, model)
+            self.load_model_data_from_files(path, model)
             self.session.commit()
 
     def load_model_data_collection(self, path, model):
@@ -284,6 +283,7 @@ class StatikDatabase(object):
     def load_model_data_from_files(self, path, model):
         db_model = globals()[model.name]
         entry_files = list_files(path, ['yml', 'yaml', 'md'])
+        entry_files = [f for f in entry_files if not(f.endswith("_all.yml"))]
         seen_entries = set()
         logger.debug("Loading %d instance(s) for model: %s", len(entry_files), model.name)
         for entry_file in entry_files:


### PR DESCRIPTION
This is a cherry-pick of 6e5dc922 from #67 .

I've tested it, and it works.

I can see some benefit in this, e.g. allowing _all.yml to contain vetted stable entries, or an archive, while new data files are created for new items, which might be migrated to _all.yml at a later date.

A database constraint occurs if the _all.yml and an individual data file contain the same key, which is appropriate.  A follow up task can improve that to provide a better contextual message.