### PR TITLE
Content field from _all.yml files are now loaded.

### DIFF
--- a/statik/common.py
+++ b/statik/common.py
@@ -56,7 +56,8 @@ class ContentLoadable(object):
     loading content and metadata from a Markdown file.
     """
     def __init__(self, filename=None, file_type=None, from_string=None, from_dict=None,
-            name=None, markdown_config=None, encoding='utf-8', error_context=None):
+            name=None, markdown_config=None, encoding='utf-8', error_context=None,
+            content_field=None):
         self.vars = None
         self.content = None
         self.file_content = None
@@ -102,7 +103,6 @@ class ContentLoadable(object):
                 "filename", "from_string", "from_dict",
                 context=self.error_context
             )
-
         if name is not None:
             self.name = name
         elif self.filename is not None:
@@ -112,7 +112,27 @@ class ContentLoadable(object):
                 "name", "filename",
                 context=self.error_context
             )
-
+        markdown_ext = [
+            MarkdownYamlMetaExtension(),
+            MarkdownLoremIpsumExtension(error_context=self.error_context)
+        ]
+        if self.markdown_config:
+            if self.markdown_config.enable_permalinks:
+                markdown_ext.append(
+                    MarkdownPermalinkExtension(
+                        permalink_text=self.markdown_config.permalink_text,
+                        permalink_class=self.markdown_config.permalink_class,
+                        permalink_title=self.markdown_config.permalink_title,
+                    )
+                )
+            markdown_ext.extend(self.markdown_config.extensions)
+            markdown_ext_configs = self.markdown_config.extension_config
+        else:
+            markdown_ext_configs = None
+        md = Markdown(
+            extensions=markdown_ext,
+            extension_configs=markdown_ext_configs
+        )
         # if it wasn't loaded from a dictionary
         if self.vars is None:
             if self.file_type is None:
@@ -127,26 +147,11 @@ class ContentLoadable(object):
                 if not isinstance(self.vars, dict):
                     self.vars = {}
             else:
-                markdown_ext = [
-                    MarkdownYamlMetaExtension(),
-                    MarkdownLoremIpsumExtension(error_context=self.error_context)
-                ]
-                if self.markdown_config.enable_permalinks:
-                    markdown_ext.append(
-                        MarkdownPermalinkExtension(
-                            permalink_text=self.markdown_config.permalink_text,
-                            permalink_class=self.markdown_config.permalink_class,
-                            permalink_title=self.markdown_config.permalink_title,
-                        )
-                    )
-                markdown_ext.extend(self.markdown_config.extensions)
-
-                md = Markdown(
-                    extensions=markdown_ext,
-                    extension_configs=self.markdown_config.extension_config
-                )
                 self.content = md.convert(self.file_content)
                 self.vars = md.meta
+        else:
+            if (content_field is not None) and (content_field in self.vars):
+                self.content = md.convert(self.vars[content_field])
 
         if isinstance(self.vars, dict):
             self.vars = dict_strip(self.vars)

--- a/statik/database.py
+++ b/statik/database.py
@@ -377,7 +377,8 @@ class StatikDatabase(object):
 class StatikDatabaseInstance(ContentLoadable):
 
     def __init__(self, model=None, session=None, **kwargs):
-        super(StatikDatabaseInstance, self).__init__(**kwargs)
+        super(StatikDatabaseInstance, self).__init__(content_field=model.content_field,
+                                                     **kwargs)
         if model is None:
             raise MissingParameterError("model", context=self.error_context)
         self.model = model


### PR DESCRIPTION
This is 44c12a9b from #67 , fixed up to avoid test failures.

I've not attempt to built test cases yet, as I suspect a bit more code is needed.

No doubt the commit message is correct that it allows _all.yml entries to contain a `Content` field.

But then shouldnt individual entry .yaml files also be able to have a `Content` field.  It looks like the code doesnt allow for that yet.