### PR TITLE
Added autogenerator for views and templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,5 @@ include README.rst
 include LICENSE.md
 include requirements.txt
 include CONTRIBUTORS
+include statik/templates/index_page.html
+include statik/templates/model_page.html

--- a/statik/autogen.py
+++ b/statik/autogen.py
@@ -1,0 +1,84 @@
+import os.path
+
+import yaml
+
+from statik.config import *
+from statik.fields import *
+from statik.models import *
+from statik.project import *
+from statik.templating import *
+from statik.utils import *
+
+import logging
+logger = logging.getLogger(__name__)
+
+__all__ = ['autogen']
+
+def autogen(project_path):
+    """Autogenerates views and templates for all the models in the project."""
+    generate_quickstart(project_path)
+
+    project = StatikProject(project_path)
+    project.config = StatikConfig(project.config_file_path)
+
+    models = list(project.load_models().values())
+
+    logger.info('Creating view and template for home page (index.html).')
+    generate_yaml_file(os.path.join(project_path, StatikProject.VIEWS_DIR, 'index.yaml'),
+                        {   
+                            'path': '/',
+                            'template': 'index'
+                        }
+    )
+    generate_index_file(os.path.join(project_path, StatikProject.TEMPLATES_DIR, 'index.jinja2'))
+
+    for model in models:
+        logger.info('Creating view and template for model: %s' % model.name)
+        generate_yaml_file(os.path.join(project_path, StatikProject.VIEWS_DIR, '%s.yaml' % model.name),
+                            {   
+                                'path': {
+                                    'template': '/%s/{{ %s.pk }}' % (model.name, model.name),
+                                    'for-each': {
+                                        '%s' % model.name: 'session.query(%s).all()' % model.name
+                                    }
+                                },
+                                'template': ('%s' % model.name),
+                            }
+        )
+        generate_model_file(os.path.join(project_path, StatikProject.TEMPLATES_DIR, '%s.jinja2' % model.name),
+                            project,
+                            model,
+                            model.fields.values())
+
+
+def generate_yaml_file(filename, contents):
+    """Creates a yaml file with the given content."""
+    with open(filename, 'w') as file:
+        file.write(yaml.dump(contents, default_flow_style=False))
+
+
+def generate_index_file(filename):
+    """Constructs a default home page for the project."""
+    with open(filename, 'w') as file:
+        content = open(os.path.join(os.path.dirname(__file__), 'templates/index_page.html'), 'r').read()
+        file.write(content)
+
+
+def generate_model_file(filename, project, model, fields):
+    """Creates a webpage for a given instance of a model."""
+    for field in fields:
+        field.type = field.__class__.__name__
+
+    content = open(os.path.join(os.path.dirname(__file__), 'templates/model_page.html'), 'r').read()
+
+    engine = StatikTemplateEngine(project)
+    template = engine.create_template(content)
+
+    # create context and update from project.config
+    context = {'model': model,
+                'fields': fields}
+    context.update(dict(project.config.context_static))
+    string = template.render(context)
+
+    with open(filename, 'w') as file:
+        file.write(string)

--- a/statik/cmdline.py
+++ b/statik/cmdline.py
@@ -12,6 +12,7 @@ import colorlog
 
 from statik.generator import generate
 from statik.utils import generate_quickstart, get_project_config_file
+from statik.autogen import autogen
 from statik.watcher import watch
 from statik.project import StatikProject
 from statik.errors import StatikError, StatikErrorContext
@@ -61,6 +62,11 @@ def main():
     parser.add_argument(
         '--quickstart',
         help="Statik will generate a basic directory structure for you in the project directory and exit.",
+        action='store_true',
+    )
+    parser.add_argument(
+        '--autogen',
+        help="Statik will generate default views and templates in the project directory for all the models.",
         action='store_true',
     )
 
@@ -202,6 +208,8 @@ def main():
             )
         elif args.quickstart:
             generate_quickstart(project_path)
+        elif args.autogen:
+            autogen(project_path)
         else:
             if args.host and '--host=localhost' in sys.argv[1:]:
                 logger.warning("Ignoring --host argument because --watch is not specified")

--- a/statik/templates/index_page.html
+++ b/statik/templates/index_page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{{ site_title }}</title>
+    </head>
+    <body>
+        index
+    </body>
+</html>

--- a/statik/templates/model_page.html
+++ b/statik/templates/model_page.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{{ site_title }}</title>
+    </head>
+    <body>
+
+    {% for field in fields %}
+        {% if field.type == 'StatikStringField' %}
+            <li>{{ field.name }}: {{ '{{' }} {{ model.name }}.{{ field.name }} {{ '}}' }}</li>
+        {% elif field.type == 'StatikForeignKeyField' %}
+            <li>{{ field.name }}: {{ '{{' }} {{ model.name }}.{{ field.name }}.pk {{ '}}' }}</li>
+        {% elif field.type == 'StatikManyToManyField' %}
+            <li>{{ field.name }}:</li>
+            <ul>
+            {{ '{% for item in ' }} {{ model.name}}.{{ field.name }} {{ '%}' }}
+                <li>{{ '{{ item.pk }}' }}</li>
+            {{ '{% endfor %} '}}
+            </ul>
+        {% endif %}
+    {% endfor %}
+
+    </body>
+</html>


### PR DESCRIPTION
This adds the functionality of automatically generating default views and templates to the statik library.
Can be used by `statik --autogen` and Statik automatically creates basic views and templates for all the models present.
Also, created a new file `autogen.py` for the same purpose.

Closes https://github.com/thanethomson/statik/issues/77