### PR TITLE
database.py: Preserve default list value order

### DIFF
--- a/statik/database.py
+++ b/statik/database.py
@@ -463,11 +463,17 @@ class StatikDatabaseInstance(ContentLoadable):
                     (field.field_type, missing_items)
                 )
 
+                original_values = self.field_values[field_name]
+
                 self.field_values[field_name] = self.session.query(
                     other_model
                 ).filter(
                     other_model.pk.in_(self.field_values[field_name])
-                )
+                ).all()
+
+                # Ensure that values appear in original order
+                self.field_values[field_name].sort(
+                    key=lambda x: original_values.index(x.pk))
 
         # populate any Content field for this model
         if self.model.content_field is not None:

--- a/tests/modular/test_database.py
+++ b/tests/modular/test_database.py
@@ -121,18 +121,15 @@ class TestStatikDatabase(unittest.TestCase):
         room_tags = db.session.query(RoomTag).order_by(RoomTag.pk).all()
         self.assertEqual(5, len(room_tags))
 
-        blueroom_tags = set([tag.pk for tag in guesthouse_rooms[0].tags])
+        blueroom_tags = list([tag.pk for tag in guesthouse_rooms[0].tags])
         self.assertEqual(4, len(blueroom_tags))
-        self.assertIn('fireplace', blueroom_tags)
-        self.assertIn('double-bed', blueroom_tags)
-        self.assertIn('balcony', blueroom_tags)
-        self.assertIn('shower', blueroom_tags)
+        self.assertEqual(
+            ['fireplace', 'double-bed', 'balcony', 'shower'], blueroom_tags)
 
-        redroom_tags = set([tag.pk for tag in guesthouse_rooms[1].tags])
+        redroom_tags = list([tag.pk for tag in guesthouse_rooms[1].tags])
         self.assertEqual(3, len(redroom_tags))
-        self.assertIn('fireplace', redroom_tags)
-        self.assertIn('single-bed', redroom_tags)
-        self.assertIn('shower', redroom_tags)
+        self.assertEqual(
+            ['fireplace', 'single-bed', 'shower'], redroom_tags)
 
     def assertInstanceEqual(self, expected, inst):
         for field_name, field_value in iteritems(expected):


### PR DESCRIPTION
This ensures that the default list value order
will be the order in the resulting output.

Fixes https://github.com/thanethomson/statik/issues/76