### PR TITLE
Allow access to variables defined in config in views

### DIFF
--- a/statik/context.py
+++ b/statik/context.py
@@ -44,12 +44,12 @@ class StatikContext(object):
     def __str__(self):
         return repr(self)
 
-    def build_dynamic(self, db, safe_mode=False):
+    def build_dynamic(self, db, extra=None, safe_mode=False):
         """Builds the dynamic context based on our current dynamic context entity and the given
         database."""
         result = dict()
         for var, query in iteritems(self.dynamic):
-            result[var] = db.query(query, safe_mode=safe_mode)
+            result[var] = db.query(query, safe_mode=safe_mode, additional_locals=extra)
         return result
 
     def build_for_each(self, db, safe_mode=False, extra=None):
@@ -68,7 +68,7 @@ class StatikContext(object):
         result = copy(self.initial)
         result.update(self.static)
         if self.dynamic:
-            result.update(self.build_dynamic(db, safe_mode=safe_mode))
+            result.update(self.build_dynamic(db, extra=extra, safe_mode=safe_mode))
         if self.for_each and for_each_inst:
             result.update(self.build_for_each(db, safe_mode=safe_mode, extra=extra))
         if isinstance(extra, dict):

--- a/tests/modular/test_context.py
+++ b/tests/modular/test_context.py
@@ -1,0 +1,16 @@
+# -*- coding:utf-8 -*-
+import unittest
+
+from statik.context import StatikContext
+from statik.database import StatikDatabase
+
+
+class TestStatikContext(unittest.TestCase):
+    def test_build_context(self):
+        context = StatikContext(dynamic={'render_elm': 'True if my_var > 10 else False'})
+
+        result = context.build(db=StatikDatabase(models={}, data_path=''), extra={'my_var': 30})
+        assert result.get('render_elm') is True
+
+        result = context.build(db=StatikDatabase(models={}, data_path=''), extra={'my_var': 5})
+        assert result.get('render_elm') is False


### PR DESCRIPTION
Context defined in the config can now be accessed in views

Closes https://github.com/thanethomson/statik/issues/54

Variables defined in the config can now be used in the same way it was used in the issue.