### PR TITLE
database.py: Allow for multiple foreign keys in same document

### DIFF
--- a/statik/database.py
+++ b/statik/database.py
@@ -574,8 +574,10 @@ def db_model_factory(Base, model, all_models):
                             model.name, field_name
                         )
 
+                    foreign_key = model_fields.get('%s_id' % field.name, None)
                     model_fields[field.name] = relationship(
                         field.field_type,
+                        foreign_keys=[foreign_key],
                         **kwargs
                     )
 

--- a/tests/modular/data_test_database/Address/adanac.yml
+++ b/tests/modular/data_test_database/Address/adanac.yml
@@ -1,0 +1,2 @@
+street: Adanac
+postal_code: V5K 2S6

--- a/tests/modular/data_test_database/Address/washington.yml
+++ b/tests/modular/data_test_database/Address/washington.yml
@@ -1,0 +1,2 @@
+street: Washington
+postal_code: V5M 2H9

--- a/tests/modular/data_test_database/Guest/gmerriweather.yml
+++ b/tests/modular/data_test_database/Guest/gmerriweather.yml
@@ -1,3 +1,5 @@
 first-name: Gary
 last-name: Merriweather
 email: gmerriweather@somewhere.com
+home_address: adanac
+business_address: washington

--- a/tests/modular/data_test_database/Guest/manderson.yml
+++ b/tests/modular/data_test_database/Guest/manderson.yml
@@ -1,3 +1,5 @@
 first-name: Michael
 last-name: Anderson
 email: manderson@somewhere.com
+home_address: adanac
+business_address: washington


### PR DESCRIPTION
Allow for multiple foreign keys in the same document by telling
SQLAlchemy which foreign key to look for.

Closes https://github.com/thanethomson/statik/issues/27