### PR TITLE
Fix for SFTP remote uploading

### DIFF
--- a/statik/config.py
+++ b/statik/config.py
@@ -73,6 +73,8 @@ class StatikConfig(YamlLoadable):
                 DEFAULT_TEMPLATE_PROVIDERS,
                 context=self.error_context
             )
+            
+        self.remote = self.vars.get("remote")
 
         logging.debug("%s", self)
 


### PR DESCRIPTION
This is the fix for issue #107 

I was unable to get the SFTP remote upload working. This is the error I was getting when running the `statik -u SFTP` command:

```
Exception caught while attempting to generate project
Traceback (most recent call last):
  File "/home/stuart/.local/share/virtualenvs/tiny-i4BzTY3h/lib/python3.6/site-packages/statik/cmdline.py", line 218, in main
    rm_remote=args.clear_remote
  File "/home/stuart/.local/share/virtualenvs/tiny-i4BzTY3h/lib/python3.6/site-packages/statik/upload.py", line 48, in upload_sftp
    ssh_config = StatikConfig(input_path).remote['sftp']
AttributeError: 'StatikConfig' object has no attribute 'remote'
```

After some digging around in the code I fixed it by adding the following line to the `__init__` method in the `StatikConfig` class (I added it to line 72):

```python
        self.remote = self.vars.get("remote")
```

With that single line added, I was able to publish to SFTP successfully.