### PR TITLE
Fix sorting error on self-referencing fields

### DIFF
--- a/statik/database.py
+++ b/statik/database.py
@@ -160,7 +160,7 @@ class StatikDatabase(object):
                 model = self.models[model_names[i]]
                 # check if this model has any dependencies which haven't been taken care of in this round
                 for foreign_model_name in model.foreign_models:
-                    if foreign_model_name not in sorted_models:
+                    if foreign_model_name not in sorted_models and foreign_model_name != model.name:
                         sorted_models.append(foreign_model_name)
 
                 if model.name not in sorted_models:


### PR DESCRIPTION
There is a chance that model will be sorted wrong if self-referencing model coexists with foreign models.

How to reproduce:
1. Open project [test.tar.gz](https://github.com/thanethomson/statik/files/3916931/test.tar.gz)
2. Run `statik --watch --no-browser -v` several times.

```2019-12-03 05:41:47,292 statik.database DEBUG   Creating 3 database table(s)...                                                                                                             
2019-12-03 05:41:47,299 statik.database DEBUG   Unsorted models: ['File', 'Info', 'Tag']                                                                                                    
2019-12-03 05:41:47,300 statik.database DEBUG   Sorting round: 1 (['File', 'Info', 'Tag'])                                                                                                  
2019-12-03 05:41:47,300 statik.database DEBUG   Sorting round: 2 (['Tag', 'File', 'Info'])                                                 
2019-12-03 05:41:47,301 statik.database DEBUG   Sorted models: ['Tag', 'File', 'Info'] (2 rounds)                   
2019-12-03 05:41:47,301 statik.database DEBUG   Loading data for model: Tag                                                                                                                 
2019-12-03 05:41:47,303 statik.database DEBUG   Loading 3 instance(s) for model: Tag                                                                  
2019-12-03 05:41:47,303 statik.database DEBUG   StatikDatabaseInstance(model=Tag, pk=0, value=tag1)                                  
2019-12-03 05:41:47,313 statik.database DEBUG   StatikDatabaseInstance(model=Tag, pk=1, value=tag2)                                                   
2019-12-03 05:41:47,314 statik.database DEBUG   StatikDatabaseInstance(model=Tag, pk=2, value=tag3)                            
2019-12-03 05:41:47,314 statik.database DEBUG   Loading 0 instance(s) for model: Tag                                                                  
2019-12-03 05:41:47,317 statik.database DEBUG   Loading data for model: File                                                         
2019-12-03 05:41:47,324 statik.database DEBUG   Loading 4 instance(s) for model: File                                                                 
2019-12-03 05:41:47,324 statik.database DEBUG   Attempting to look up primary keys for ManyToMany field relationship: ['0', '1', '2']
2019-12-03 05:41:47,326 statik.database WARNING 0 not found in <class 'statik.database.Info'>                                                  
2019-12-03 05:41:47,327 statik.database WARNING 1 not found in <class 'statik.database.Info'>                                                                                               
2019-12-03 05:41:47,335 statik.database WARNING 2 not found in <class 'statik.database.Info'>```

Expected behaviour: `Sorted models: ['Info', 'Tag', 'File']`